### PR TITLE
Add support for Twig and Nunjucks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ObsoHTML, the Obsolete HTML Checker
 
-ObsoHTML is a Node.js script designed to scan HTML, PHP, JavaScript, and TypeScript files for obsolete or proprietary HTML attributes and elements (in scripts, it would catch JSX syntax). It helps you identify and update deprecated HTML code to be more sure to use web standards.
+ObsoHTML is a Node.js script designed to scan HTML, PHP, Nunjucks, Twig, JavaScript, and TypeScript files for obsolete or proprietary HTML attributes and elements (in scripts, it would catch JSX syntax). It helps you identify and update deprecated HTML code to be more sure to use web standards.
 
 ## Usage
 

--- a/bin/obsohtml.js
+++ b/bin/obsohtml.js
@@ -78,7 +78,7 @@ function walkDirectory(directory, verbose) {
         if (file !== 'node_modules') {
           walkDirectory(fullPath, verbose);
         }
-      } else if (fullPath.endsWith('.html') || fullPath.endsWith('.htm') || fullPath.endsWith('.php') || fullPath.endsWith('.js') || fullPath.endsWith('.ts')) {
+      } else if (fullPath.endsWith('.html') || fullPath.endsWith('.htm') || fullPath.endsWith('.php') || fullPath.endsWith('.njk') || fullPath.endsWith('.twig') || fullPath.endsWith('.js') || fullPath.endsWith('.ts')) {
         findObsolete(fullPath);
       }
     } catch (err) {

--- a/bin/obsohtml.test.js
+++ b/bin/obsohtml.test.js
@@ -56,6 +56,7 @@ describe('ObsoHTML', () => {
   test('Detect obsolete minimized attributes', () => {
     const result = spawnSync('node', ['bin/obsohtml.js', '-f', tempDir], { encoding: 'utf-8' });
     expect(result.stdout).toContain("Found obsolete attribute 'noshade'");
+    expect(result.stdout).not.toContain("Found obsolete attribute 'nowrap'");
   });
 
   test('Detect obsolete elements in Twig file', () => {

--- a/bin/obsohtml.test.js
+++ b/bin/obsohtml.test.js
@@ -7,6 +7,7 @@ describe('ObsoHTML', () => {
   const tempFile = path.join(tempDir, 'test.html');
   const tempFileWithAttributes = path.join(tempDir, 'test_with_attributes.html');
   const tempFileWithMinimizedAttributes = path.join(tempDir, 'test_with_minimized_attributes.html');
+  const tempTwigFile = path.join(tempDir, 'test.twig');
 
   beforeAll(() => {
     // Create a temporary directory and files
@@ -16,6 +17,7 @@ describe('ObsoHTML', () => {
     fs.writeFileSync(tempFile, '<!DOCTYPE html><html><title>Test</title><body><center>Test</center></body></html>');
     fs.writeFileSync(tempFileWithAttributes, '<!DOCTYPE html><html><title>Test</title><body><img src=test.jpg alt=Test align=left></body></html>');
     fs.writeFileSync(tempFileWithMinimizedAttributes, '<!DOCTYPE html><html><title>Test</title><hr noshade><!-- this is not a <table> with a nowrap attribute -->');
+    fs.writeFileSync(tempTwigFile, '<!DOCTYPE html><html><title>Test</title><isindex>');
   });
 
   afterAll(() => {
@@ -23,6 +25,7 @@ describe('ObsoHTML', () => {
     fs.unlinkSync(tempFile);
     fs.unlinkSync(tempFileWithAttributes);
     fs.unlinkSync(tempFileWithMinimizedAttributes);
+    fs.unlinkSync(tempTwigFile);
     fs.rmdirSync(tempDir);
   });
 
@@ -53,5 +56,10 @@ describe('ObsoHTML', () => {
   test('Detect obsolete minimized attributes', () => {
     const result = spawnSync('node', ['bin/obsohtml.js', '-f', tempDir], { encoding: 'utf-8' });
     expect(result.stdout).toContain("Found obsolete attribute 'noshade'");
+  });
+
+  test('Detect obsolete elements in Twig file', () => {
+    const result = spawnSync('node', ['bin/obsohtml.js', '-f', tempDir], { encoding: 'utf-8' });
+    expect(result.stdout).toContain("Found obsolete element 'isindex'");
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@j9t/obsohtml",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@j9t/obsohtml",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "CC-BY-SA-4.0",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@j9t/obsohtml",
   "description": "Find obsolete HTML elements and attributes",
   "author": "Jens Oliver Meiert",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "license": "CC-BY-SA-4.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded the list of supported file types for the ObsoHTML tool to include Nunjucks and Twig templates.
	- Enhanced functionality for analyzing obsolete content in additional templating languages.
  
- **Tests**
	- Introduced a new test case for detecting obsolete elements specifically in Twig files.

- **Chores**
	- Updated version number from 1.5.0 to 1.6.0, indicating new features and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->