### PR TITLE
refactor: replace chalk with native `styleText` function

### DIFF
--- a/bin/obsohtml.js
+++ b/bin/obsohtml.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const path = require('path');
-const os = require('os');
 const { Command } = require('commander');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const program = new Command();
+const { styleText } = require('node:util');
 
 // List of obsolete or proprietary HTML elements
 const obsoleteElements = [
@@ -21,14 +22,14 @@ const defaultProjectDirectory = os.homedir();
 
 // Function to find obsolete elements and attributes in a file
 async function findObsolete(filePath) {
-  const chalk = await import('chalk');
   const content = fs.readFileSync(filePath, 'utf8');
 
   // Check for obsolete elements
   obsoleteElements.forEach(element => {
     const elementRegex = new RegExp(`<\\s*${element}\\b`, 'i');
     if (elementRegex.test(content)) {
-      console.log(chalk.default.blue(`Found obsolete element ${chalk.default.bold(`'${element}'`)} in ${filePath}`));
+      const message = styleText('blue', `Found obsolete element ${styleText('bold', `'${element}'`)} in ${filePath}`);
+      console.log(message);
     }
   });
 
@@ -36,7 +37,8 @@ async function findObsolete(filePath) {
   obsoleteAttributes.forEach(attribute => {
     const attributeRegex = new RegExp(`<[^>]*\\s${attribute}\\b(\\s*=\\s*(?:"[^"]*"|'[^']*'|[^"'\\s>]+))?\\s*(?=/?>)`, 'i');
     if (attributeRegex.test(content)) {
-      console.log(chalk.default.green(`Found obsolete attribute ${chalk.default.bold(`'${attribute}'`)} in ${filePath}`));
+      const message = styleText('green', `Found obsolete attribute ${styleText('bold', `'${attribute}'`)} in ${filePath}`);
+      console.log(message);
     }
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "@j9t/obsohtml",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@j9t/obsohtml",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "CC-BY-SA-4.0",
       "dependencies": {
-        "chalk": "^5.4.1",
         "commander": "^13.0.0"
       },
       "bin": {
@@ -1477,9 +1476,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001651",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
-      "integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==",
+      "version": "1.0.30001700",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
+      "integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
       "dev": true,
       "funding": [
         {
@@ -1496,17 +1495,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
     },
     "node_modules/char-regex": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,30 +1,29 @@
 {
-  "name": "@j9t/obsohtml",
-  "description": "Find obsolete HTML elements and attributes",
   "author": "Jens Oliver Meiert",
-  "version": "1.7.0",
-  "license": "CC-BY-SA-4.0",
-  "repository": {
-    "type": "git",
-    "url": "git+ssh://git@github.com/j9t/obsohtml.git"
+  "bin": {
+    "obsohtml": "bin/obsohtml.js"
+  },
+  "dependencies": {
+    "commander": "^13.0.0"
+  },
+  "description": "Find obsolete HTML elements and attributes",
+  "devDependencies": {
+    "jest": "^29.7.0"
   },
   "homepage": "https://github.com/j9t/obsohtml",
   "keywords": [
     "html",
     "qa"
   ],
-  "bin": {
-    "obsohtml": "bin/obsohtml.js"
+  "license": "CC-BY-SA-4.0",
+  "name": "@j9t/obsohtml",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/j9t/obsohtml.git"
   },
   "scripts": {
     "start": "node ./bin/obsohtml.js",
     "test": "jest"
   },
-  "dependencies": {
-    "chalk": "^5.4.1",
-    "commander": "^13.0.0"
-  },
-  "devDependencies": {
-    "jest": "^29.7.0"
-  }
+  "version": "1.8.0"
 }


### PR DESCRIPTION
Replaced the 'chalk' library with a native `styleText` utility for text styling, reducing external dependencies and simplifying the code. Updated `package.json` and `package-lock.json` to remove 'chalk' and bump the version to 1.8.0.

(This commit message was AI-generated.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This release brings enhanced console output styling and streamlined project configuration. Users will notice improved formatting in log messages along with cleaner version and dependency details.

- **Refactor**
  - Transitioned to a built-in formatting method for clear, bold, and colored console messages.
- **Chores**
  - Updated project configuration with a version bump and refined dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->