### PR TITLE
chore: bump version to 1.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@j9t/obsohtml",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@j9t/obsohtml",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "CC-BY-SA-4.0",
       "dependencies": {
         "commander": "^14.0.0"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
     "start": "node ./bin/obsohtml.js",
     "test": "jest"
   },
-  "version": "1.8.0"
+  "version": "1.8.1"
 }


### PR DESCRIPTION
Update the version in package.json and package-lock.json to 1.8.1 to reflect the latest release. No other changes were made.

(This commit message was AI-generated.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to 1.8.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->