### PR TITLE
Fix attribute-in-quoted-value false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ As of version 1.10.0, all notable changes to ObsoHTML are documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.1] - 2026-05-11
+
+### Fixed
+
+- Fixed false positives where obsolete attribute names (e.g., `scrolling`, `background`, `border`) appeared as text inside quoted attribute values (e.g., `content="Infinite scrolling"`)
+
 ## [1.10.0] - 2026-04-11
 
 ### Added

--- a/bin/obsohtml.test.js
+++ b/bin/obsohtml.test.js
@@ -195,4 +195,18 @@ describe('`checkMarkup`', () => {
     const { elements } = checkMarkup('<centers>Hello</centers>');
     assert.deepEqual(elements, []);
   });
+
+  test('Do not flag an obsolete attribute name appearing inside a quoted attribute value', () => {
+    // “scrolling” inside `content="…"`, “background” inside `content="…"`, and
+    // “border” inside `alt="…"` are all text—not actual HTML attributes
+    const cases = [
+      '<meta property="og:title" content="Infinite scrolling on the web">',
+      '<meta content="Busyness and Background Noise on Websites">',
+      '<img alt="A graphic indicating a border between regions.">',
+    ];
+    for (const html of cases) {
+      const { attributes } = checkMarkup(html);
+      assert.deepEqual(attributes, [], `Expected no attributes for: ${html}`);
+    }
+  });
 });

--- a/bin/obsohtml.test.js
+++ b/bin/obsohtml.test.js
@@ -203,6 +203,7 @@ describe('`checkMarkup`', () => {
       '<meta property="og:title" content="Infinite scrolling on the web">',
       '<meta content="Busyness and Background Noise on Websites">',
       '<img alt="A graphic indicating a border between regions.">',
+      "<img alt='A graphic indicating a border between regions.'>",
     ];
     for (const html of cases) {
       const { attributes } = checkMarkup(html);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsohtml",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsohtml",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0"

--- a/package.json
+++ b/package.json
@@ -43,5 +43,5 @@
   },
   "type": "module",
   "types": "src/index.d.ts",
-  "version": "1.10.0"
+  "version": "1.10.1"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -17,8 +17,8 @@ const attributeRegexes = new Map(
   obsoleteAttributes.map(attribute => [
     attribute,
     // Matches the attribute preceded by whitespace anywhere in a tag, without
-    // requiring it to be the last attribute before the closing bracket.
-    new RegExp(`<[^>]*\\s${attribute}\\b(\\s*=\\s*(?:"[^"]*"|'[^']*'|[^"'\\s>]+))?`, 'i'),
+    // requiring it to be the last attribute before the closing bracket
+    new RegExp(`<(?:[^>"']|"[^"]*"|'[^']*')*\\s${attribute}\\b(\\s*=\\s*(?:"[^"]*"|'[^']*'|[^"'\\s>]+))?`, 'i'),
   ])
 );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false positives where obsolete HTML attribute names (such as `scrolling`, `background`, `border`) were incorrectly flagged when appearing as text within quoted attribute values.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j9t/obsohtml/pull/44)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->