### PR TITLE
Update CLI to simplify arguments and improve defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ As of version 1.10.0, all notable changes to ObsoHTML are documented in this fil
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-08-12
+
+### Changed
+
+* **BREAKING:** Changed to default to the current directory instead of the user’s home directory when no path is given
+* **BREAKING:** Removed `-f`/`--folder`, replaced by the positional argument
+* Accepted the path as a positional argument (`obsohtml path/to/folder`)
+* Changed to fail with a message and a non-zero exit when the given path doesn’t exist
+
 ## [1.10.2] - 2026-08-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -20,28 +20,34 @@ npx obsohtml
 
 #### Execution
 
-ObsoHTML accepts a folder or file path as a command line option, which can be specified in both short form (`-f`) and long form (`--folder`). The path can be either absolute or relative.
+ObsoHTML accepts a folder or file path as an argument. The path can be either absolute or relative; when it’s omitted, ObsoHTML checks the current directory.
 
 ObsoHTML can be run in “verbose” mode by appending `-v` or `--verbose` to the command. This will show information about files and directories that were skipped.
 
 ##### Example Commands
 
-Use the default directory (user home directory):
+Check the current directory:
 
 ```shell
 npx obsohtml
 ```
 
-Specify a folder using an absolute path (easiest and most common use case):
+Specify a folder using an absolute path:
 
 ```shell
-npx obsohtml -f /path/to/folder
+npx obsohtml /path/to/folder
 ```
 
 Specify a folder using a relative path:
 
 ```shell
-npx obsohtml -f ../path/to/folder
+npx obsohtml ../path/to/folder
+```
+
+Specify a single file:
+
+```shell
+npx obsohtml src/index.html
 ```
 
 ### 2. Programmatic Use

--- a/bin/obsohtml.js
+++ b/bin/obsohtml.js
@@ -2,7 +2,6 @@
 
 import { Command } from 'commander';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { styleText } from 'node:util';
 import { checkMarkup } from '../src/index.js';
@@ -12,8 +11,8 @@ const program = new Command();
 // Directories to skip during traversal
 const EXCLUDED_DIRS = new Set(['node_modules', '.git', 'dist', 'build', 'vendor']);
 
-// Default project directory (user’s home directory)
-const defaultProjectDirectory = os.homedir();
+// Default project directory (the working directory)
+const defaultProjectDirectory = '.';
 
 // Track whether any obsolete HTML was found
 let foundObsolete = false;
@@ -98,7 +97,13 @@ function main(projectDirectory = defaultProjectDirectory, verbose = false) {
     if (err.code !== 'ENOENT') throw err;
   }
 
-  if (stats?.isFile()) {
+  // A named target that isn’t there is the user’s to fix
+  if (!stats) {
+    console.error(styleText('red', `No such file or directory: ${projectDirectory}`));
+    process.exit(1);
+  }
+
+  if (stats.isFile()) {
     findObsolete(projectDirectory);
   } else {
     walkDirectory(projectDirectory, verbose);
@@ -107,14 +112,16 @@ function main(projectDirectory = defaultProjectDirectory, verbose = false) {
   if (foundObsolete) process.exit(1);
 }
 
-// Define command line options
+// Define command line arguments and options
 program
-  .option('-f, --folder <path>', 'specify the project directory', defaultProjectDirectory)
+  .argument('[path]', 'folder or file to check (default: current directory)')
   .option('-v, --verbose', 'enable verbose output')
   .parse(process.argv);
 
 // Get the project directory and verbose flag from command line arguments or use the default
 const options = program.opts();
-const projectDirectory = options.folder;
+const [positional] = program.args;
+
+const projectDirectory = positional || defaultProjectDirectory;
 const verbose = options.verbose;
 main(projectDirectory, verbose);

--- a/bin/obsohtml.js
+++ b/bin/obsohtml.js
@@ -94,7 +94,9 @@ function main(projectDirectory = defaultProjectDirectory, verbose = false) {
   try {
     stats = fs.lstatSync(projectDirectory);
   } catch (err) {
-    if (err.code !== 'ENOENT') throw err;
+    // ENOTDIR is a path below an existing file—unresolvable the same way a
+    // missing one is, so it gets the same message rather than a stack trace
+    if (err.code !== 'ENOENT' && err.code !== 'ENOTDIR') throw err;
   }
 
   // A named target that isn’t there is the user’s to fix

--- a/bin/obsohtml.test.js
+++ b/bin/obsohtml.test.js
@@ -123,6 +123,14 @@ describe('ObsoHTML', () => {
     assert.strictEqual(status, 1);
   });
 
+  // `lstat()` reports a path below an existing file as ENOTDIR, not ENOENT
+  test('Fail on a target whose parent is a file', () => {
+    const { stderr, status } = run([path.join(tempFile, 'nested')]);
+    assert.ok(stderr.includes('No such file or directory'));
+    assert.ok(!stderr.includes('ENOTDIR'), 'Should not surface a raw stack trace');
+    assert.strictEqual(status, 1);
+  });
+
   test('Check the working directory when no path is given', () => {
     const { stdout } = run([], { cwd: tempDir });
     assert.ok(stdout.includes("Found obsolete element 'center'"));

--- a/bin/obsohtml.test.js
+++ b/bin/obsohtml.test.js
@@ -10,8 +10,8 @@ import { checkMarkup, obsoleteElements, obsoleteAttributes } from '../src/index.
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const scriptPath = path.join(__dirname, 'obsohtml.js');
 
-function run(args) {
-  const result = spawnSync('node', [scriptPath, ...args], { encoding: 'utf-8' });
+function run(args, options = {}) {
+  const result = spawnSync('node', [scriptPath, ...args], { encoding: 'utf-8', ...options });
   return {
     stdout: stripVTControlCharacters(result.stdout),
     stderr: stripVTControlCharacters(result.stderr),
@@ -54,55 +54,55 @@ describe('ObsoHTML', () => {
   });
 
   test('Detect obsolete elements', () => {
-    const { stdout } = run(['-f', tempDir]);
+    const { stdout } = run([tempDir]);
     assert.ok(stdout.includes("Found obsolete element 'center'"));
   });
 
   test('Detect obsolete attributes', () => {
-    const { stdout } = run(['-f', tempDir]);
+    const { stdout } = run([tempDir]);
     assert.ok(stdout.includes("Found obsolete attribute 'align'"));
   });
 
   test('Detect obsolete elements and attributes using absolute path', () => {
-    const { stdout } = run(['-f', path.resolve(tempDir)]);
+    const { stdout } = run([path.resolve(tempDir)]);
     assert.ok(stdout.includes("Found obsolete element 'center'"));
     assert.ok(stdout.includes("Found obsolete attribute 'align'"));
   });
 
   test('Detect obsolete elements and attributes using relative path', () => {
-    const { stdout } = run(['--folder', path.relative(process.cwd(), tempDir)]);
+    const { stdout } = run([path.relative(process.cwd(), tempDir)]);
     assert.ok(stdout.includes("Found obsolete element 'center'"));
     assert.ok(stdout.includes("Found obsolete attribute 'align'"));
   });
 
   test('Detect obsolete minimized attributes', () => {
-    const { stdout } = run(['-f', tempDir]);
+    const { stdout } = run([tempDir]);
     assert.ok(stdout.includes("Found obsolete attribute 'noshade'"));
     assert.ok(!stdout.includes("Found obsolete attribute 'nowrap'"));
   });
 
   test('Detect obsolete elements in Twig file', () => {
-    const { stdout } = run(['-f', tempDir]);
+    const { stdout } = run([tempDir]);
     assert.ok(stdout.includes("Found obsolete element 'isindex'"));
   });
 
   test('Detect obsolete attribute when it is not the last attribute in a tag', () => {
-    const { stdout } = run(['-f', tempFileWithMidTagAttribute]);
+    const { stdout } = run([tempFileWithMidTagAttribute]);
     assert.ok(stdout.includes("Found obsolete attribute 'align'"));
   });
 
   test('Detect obsolete elements in JSX file', () => {
-    const { stdout } = run(['-f', tempJsxFile]);
+    const { stdout } = run([tempJsxFile]);
     assert.ok(stdout.includes("Found obsolete element 'center'"));
   });
 
   test('Detect obsolete elements in TSX file', () => {
-    const { stdout } = run(['-f', tempTsxFile]);
+    const { stdout } = run([tempTsxFile]);
     assert.ok(stdout.includes("Found obsolete element 'marquee'"));
   });
 
   test('Exit with code 1 when obsolete HTML is found', () => {
-    const { status } = run(['-f', tempDir]);
+    const { status } = run([tempDir]);
     assert.strictEqual(status, 1);
   });
 
@@ -110,16 +110,29 @@ describe('ObsoHTML', () => {
     const cleanFile = path.join(tempDir, 'clean.html');
     fs.writeFileSync(cleanFile, '<!DOCTYPE html><html><title>Clean</title><body><p>No issues here.</p></body></html>');
     try {
-      const { status } = run(['-f', cleanFile]);
+      const { status } = run([cleanFile]);
       assert.strictEqual(status, 0);
     } finally {
       fs.unlinkSync(cleanFile);
     }
   });
 
-  test('Verbose mode reports skipped non-existent directory', () => {
-    const { stderr } = run(['-f', path.join(tempDir, 'nonexistent'), '-v']);
-    assert.ok(stderr.includes('Skipping non-existent directory'));
+  test('Fail on a target that does not exist', () => {
+    const { stderr, status } = run([path.join(tempDir, 'nonexistent')]);
+    assert.ok(stderr.includes('No such file or directory'));
+    assert.strictEqual(status, 1);
+  });
+
+  test('Check the working directory when no path is given', () => {
+    const { stdout } = run([], { cwd: tempDir });
+    assert.ok(stdout.includes("Found obsolete element 'center'"));
+    assert.ok(stdout.includes("Found obsolete attribute 'align'"));
+  });
+
+  test('Reject the removed `--folder` option', () => {
+    const { stderr, status } = run(['--folder', tempDir]);
+    assert.ok(stderr.includes('unknown option'));
+    assert.strictEqual(status, 1);
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsohtml",
-  "version": "1.10.2",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsohtml",
-      "version": "1.10.2",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^15.0.0"
@@ -16,8 +16,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "eslint": "^10.8.0",
-        "globals": "^17.9.0",
+        "eslint": "^10.8.1",
+        "globals": "^17.10.0",
         "typescript": "^7.0.2"
       },
       "funding": {
@@ -663,9 +663,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
-      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -903,9 +903,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
-      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
+      "version": "17.10.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.10.0.tgz",
+      "integrity": "sha512-V0kztuWST2k8A/VbxAY8+L+7+Rgo3fyA24IHRLrZp7HOzJjV0gHSaZUjK9lpP/IrBSNite2tZ1prhRkinRu1CA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "description": "HTML checker for obsolete and proprietary elements and attributes",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "eslint": "^10.8.0",
-    "globals": "^17.9.0",
+    "eslint": "^10.8.1",
+    "globals": "^17.10.0",
     "typescript": "^7.0.2"
   },
   "exports": {
@@ -49,5 +49,5 @@
   },
   "type": "module",
   "types": "src/index.d.ts",
-  "version": "1.10.2"
+  "version": "2.0.0"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The CLI now accepts an optional positional path instead of the removed `-f`/`--folder` option.
  * When no path is provided, it processes the current directory by default.
* **Bug Fixes**
  * Missing files or directories now display a clear error message and exit with a non-zero status.
* **Documentation**
  * Updated usage guidance and examples for processing directories, absolute paths, relative paths, and individual files.
* **Chores**
  * Released as version 2.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->